### PR TITLE
validate payment completed

### DIFF
--- a/ppss.module
+++ b/ppss.module
@@ -67,7 +67,7 @@ function ppss_cron(){
     //Enviar correo a usuario y marketing
     $module = 'ppss';
     $key = 'cancel_subscription';
-    $to = $subscription->mail."; marketing@noticiasnet.mx";
+    $to = $subscription->mail.";".\Drupal::config('system.site')->get('mail');
     $params['message'] = $msg;
     $params['subject'] = "Cancelación de suscripción - Encuéntralo";
     $langcode = \Drupal::currentUser()->getPreferredLangcode();


### PR DESCRIPTION
Validar los pagos recurrentes recibido: Actualizar el event_id del primer pago, si no es el primer pago realizar el registro
Enviar notificaciones al correo configurado en el sitio